### PR TITLE
Skip minification for already-minified files

### DIFF
--- a/app/code/community/Fballiano/CssjsMinify/Model/Observer.php
+++ b/app/code/community/Fballiano/CssjsMinify/Model/Observer.php
@@ -9,6 +9,11 @@ class Fballiano_CssjsMinify_Model_Observer
 {
     public const MINIFIED_FILES_FOLDER = 'fbminify';
 
+    private static function isAlreadyMinified(string $filePath): bool
+    {
+        return (bool) preg_match('/[._-](min|pack)\./', $filePath);
+    }
+
     public function httpResponseSendBefore(Varien_Event_Observer $observer): void
     {
         $response = $observer->getResponse();
@@ -37,8 +42,12 @@ class Fballiano_CssjsMinify_Model_Observer
                 $time = filemtime($baseDir . $path);
                 $hash = md5($path) . "-$time.js";
                 if (!file_exists($minifiedDir . $hash)) {
-                    $minifier = new \MatthiasMullie\Minify\JS($baseDir . $path);
-                    $minifier->minify("$minifiedDir/$hash");
+                    if (self::isAlreadyMinified($path)) {
+                        copy($baseDir . $path, $minifiedDir . $hash);
+                    } else {
+                        $minifier = new \MatthiasMullie\Minify\JS($baseDir . $path);
+                        $minifier->minify($minifiedDir . $hash);
+                    }
                 }
                 $matches[2] = $minifiedUrl . $hash;
             }
@@ -55,8 +64,12 @@ class Fballiano_CssjsMinify_Model_Observer
                 $time = filemtime($baseDir . $path);
                 $hash = md5($path) . "-$time.css";
                 if (!file_exists($minifiedDir . $hash)) {
-                    $minifier = new \MatthiasMullie\Minify\CSS($baseDir . $path);
-                    $minifier->minify("$minifiedDir/$hash");
+                    if (self::isAlreadyMinified($path)) {
+                        copy($baseDir . $path, $minifiedDir . $hash);
+                    } else {
+                        $minifier = new \MatthiasMullie\Minify\CSS($baseDir . $path);
+                        $minifier->minify($minifiedDir . $hash);
+                    }
                 }
                 $matches[2] = $minifiedUrl . $hash;
             }

--- a/app/code/community/Fballiano/CssjsMinify/etc/config.xml
+++ b/app/code/community/Fballiano/CssjsMinify/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Fballiano_CssjsMinify>
-            <version>0.1.0</version>
+            <version>1.0.0</version>
         </Fballiano_CssjsMinify>
     </modules>
     <global>


### PR DESCRIPTION
## Summary
- Detect files with `.min.`, `-min.`, `_min.`, `.pack.`, `-pack.`, or `_pack.` in the filename
- Copy these files instead of re-minifying them to prevent double-minification bugs (e.g., with TinyMCE)
- Still provides cache-busting benefits for all files

Fixes #2